### PR TITLE
:art: Update SDK to better use config

### DIFF
--- a/src/stacks-dao/cli.ts
+++ b/src/stacks-dao/cli.ts
@@ -6,22 +6,12 @@ import ora from "ora";
 
 dotenv.config();
 
-const sdk = new DaoSDK({
-  network: (process.env.NETWORK as any) || "testnet",
-  stacksApi: process.env.STACKS_API || "https://api.testnet.hiro.so",
-});
+const sdk = await DaoSDK.create();
 
 // Global options
 program
-  .name("dao")
   .description("CLI tool for managing DAOs on the Stacks blockchain")
-  .version("1.0.0")
-  .option(
-    "-n, --network <network>",
-    "network to use (mainnet/testnet)",
-    "testnet"
-  )
-  .option("-k, --key <key>", "sender private key")
+  .version("0.1.0")
   .option("-f, --fee <fee>", "transaction fee", "100000");
 
 // Create subcommands
@@ -61,7 +51,6 @@ executor
         name: options.name,
         extensions: options.extensions || [],
         includeDeployer: options.deployer,
-        senderKey: program.opts().key,
         fee: parseInt(program.opts().fee),
       });
       spinner.succeed("Deployed executor contract:");
@@ -87,7 +76,6 @@ executor
         options.extension,
         enabled,
         {
-          senderKey: program.opts().key,
           fee: parseInt(program.opts().fee),
         }
       );
@@ -128,7 +116,6 @@ treasury
       const deployed = await sdk.treasury.deploy({
         name: options.name,
         daoContractId: options.daoId,
-        senderKey: program.opts().key,
         fee: parseInt(program.opts().fee),
       });
       spinner.succeed("Deployed treasury extension:");
@@ -151,7 +138,6 @@ treasury
         options.treasury,
         parseInt(options.amount),
         {
-          senderKey: program.opts().key,
           fee: parseInt(program.opts().fee),
         }
       );
@@ -176,7 +162,6 @@ treasury
         parseInt(options.amount),
         options.recipient,
         {
-          senderKey: program.opts().key,
           fee: parseInt(program.opts().fee),
         }
       );

--- a/src/stacks-dao/lib/sdk.ts
+++ b/src/stacks-dao/lib/sdk.ts
@@ -1,27 +1,56 @@
+// src/stacks-dao/lib/sdk.ts
+
 import { Executor } from "./executor";
 import { Treasury } from "./treasury";
 import { BankAccount } from "./bank-account";
 import { Messaging } from "./messaging";
 import { Payments } from "./payments";
-import type { SDKOptions } from "../types";
+import type { SDKOptions, BaseConfig } from "../types";
+import { CONFIG, deriveChildAccount, getNetwork } from "../../utilities";
 
 export class DaoSDK {
+  private static instance: DaoSDK;
+  public static key: string;
+
   public executor: Executor;
   public treasury: Treasury;
   public bankAccount: BankAccount;
   public messaging: Messaging;
   public payments: Payments;
+  public address: string;
+  private config: BaseConfig;
 
-  constructor(options: SDKOptions = {}) {
-    const config = {
-      stacksApi: options.stacksApi || "https://api.testnet.hiro.so",
-      network: options.network || "testnet",
-    };
+  static async create(options: SDKOptions = {}): Promise<DaoSDK> {
+    if (!DaoSDK.instance) {
+      const config = {
+        stacksApi: options.stacksApi || "https://api.testnet.hiro.so",
+        network: options.network || "testnet",
+      };
+
+      const { address, key } = await deriveChildAccount(
+        CONFIG.NETWORK,
+        CONFIG.MNEMONIC,
+        CONFIG.ACCOUNT_INDEX
+      );
+
+      DaoSDK.key = key;
+      DaoSDK.instance = new DaoSDK(config, address);
+    }
+    return DaoSDK.instance;
+  }
+
+  private constructor(config: BaseConfig, address: string) {
+    this.config = config;
+    this.address = address;
 
     this.executor = new Executor(config);
     this.treasury = new Treasury(config);
     this.bankAccount = new BankAccount(config);
     this.messaging = new Messaging(config);
     this.payments = new Payments(config);
+  }
+
+  getNetwork(): "mainnet" | "testnet" {
+    return this.config.network;
   }
 }

--- a/src/stacks-dao/lib/treasury.ts
+++ b/src/stacks-dao/lib/treasury.ts
@@ -47,7 +47,7 @@ export class Treasury extends BaseComponent {
    */
   async deploy(
     options: TreasuryDeployOptions &
-      Pick<ContractDeployOptions, "senderKey" | "fee" | "nonce">
+      Pick<ContractDeployOptions, "fee" | "nonce">
   ): Promise<any> {
     const { contract: codeBody } = await this.generate(options);
 

--- a/src/stacks-dao/tests/index.test.ts
+++ b/src/stacks-dao/tests/index.test.ts
@@ -7,24 +7,14 @@ const TEST_DAO =
 const TEST_TREASURY =
   "ST2D5BGGJ956A635JG7CJQ59FTRFRB08934NHKJ95.test-dao-1734942153203-treasury";
 
-const sdk = new DaoSDK({
-  network: "testnet",
-  stacksApi: "https://api.testnet.hiro.so",
-});
-
 // Test configuration
-let senderKey: string;
+let sdk: DaoSDK;
 let daoName: string;
 let executorId: string;
 
 beforeAll(async () => {
   // Set up test environment
-  const { key } = await deriveChildAccount(
-    CONFIG.NETWORK,
-    CONFIG.MNEMONIC,
-    CONFIG.ACCOUNT_INDEX
-  );
-  senderKey = key;
+  sdk = await DaoSDK.create();
   daoName = `test-dao-${Date.now()}`; // Unique name for each test run
 });
 
@@ -46,9 +36,9 @@ describe("Executor Tests", () => {
       name: daoName,
       extensions: [],
       includeDeployer: true,
-      senderKey,
       fee: 400000,
     });
+    console.log(result);
 
     expect(result).toBeDefined();
     expect(result.txid).toBeDefined();
@@ -66,8 +56,7 @@ describe("Executor Tests", () => {
     const result = await sdk.executor.setExtension(
       TEST_DAO,
       extensionAddress,
-      true,
-      { senderKey }
+      true
     );
 
     expect(result).toBeDefined();
@@ -93,7 +82,6 @@ describe("Treasury Tests", () => {
     const result = await sdk.treasury.deploy({
       name: daoName,
       daoContractId: TEST_DAO,
-      senderKey,
       fee: 400000,
     });
 
@@ -105,8 +93,7 @@ describe("Treasury Tests", () => {
   test("should deposit STX", async () => {
     const result = await sdk.treasury.depositStx(
       TEST_TREASURY,
-      100000, // 0.1 STX
-      { senderKey }
+      100000 // 0.1 STX
     );
 
     expect(result).toBeDefined();
@@ -118,8 +105,7 @@ describe("Treasury Tests", () => {
     const result = await sdk.treasury.withdrawStx(
       TEST_TREASURY,
       50000, // 0.05 STX
-      recipient,
-      { senderKey }
+      recipient
     );
 
     expect(result).toBeDefined();

--- a/src/stacks-dao/types/index.ts
+++ b/src/stacks-dao/types/index.ts
@@ -55,7 +55,7 @@ export interface DAOActivityInfo {
 export interface ContractDeployOptions {
   contractName: string;
   codeBody: string;
-  senderKey: string;
+  senderKey?: string;
   anchorMode?: AnchorMode;
   postConditionMode?: PostConditionMode;
   postConditions?: PostCondition[];
@@ -70,7 +70,7 @@ export interface TransactionOptions {
   contractName: string;
   functionName: string;
   functionArgs: any[];
-  senderKey: string;
+  senderKey?: string;
   anchorMode?: AnchorMode;
   postConditionMode?: PostConditionMode;
   postConditions?: PostCondition[];


### PR DESCRIPTION
This pull request includes several changes to the `stacks-dao` project, focusing on refactoring the SDK initialization, removing the need for passing the sender key in various functions, and ensuring the SDK is properly initialized before use. The most important changes include updating the `DaoSDK` class to use a singleton pattern, modifying the `BaseComponent` class to utilize the SDK's key, and updating the CLI and tests to reflect these changes.

### SDK Initialization and Refactoring:

* [`src/stacks-dao/lib/sdk.ts`](diffhunk://#diff-c0fce88ae590d01232bbe4dfe549bbfd6c935ea6bba830f4dc0601460924d769R1-R55): Updated `DaoSDK` to use a singleton pattern and added a `create` method for initialization. The SDK now stores the key and address upon creation.

### Base Component Updates:

* [`src/stacks-dao/lib/base.ts`](diffhunk://#diff-cfd0d20bce78473ac26c31307eb70b210e423a25f5dd439fbe6598dc8574c006R1-R2): Modified `BaseComponent` to use the SDK's key for contract calls and deployments, ensuring the SDK is initialized before use. [[1]](diffhunk://#diff-cfd0d20bce78473ac26c31307eb70b210e423a25f5dd439fbe6598dc8574c006R1-R2) [[2]](diffhunk://#diff-cfd0d20bce78473ac26c31307eb70b210e423a25f5dd439fbe6598dc8574c006L60-R121) [[3]](diffhunk://#diff-cfd0d20bce78473ac26c31307eb70b210e423a25f5dd439fbe6598dc8574c006L118-R153) [[4]](diffhunk://#diff-cfd0d20bce78473ac26c31307eb70b210e423a25f5dd439fbe6598dc8574c006L152-R224)

### CLI Changes:

* [`src/stacks-dao/cli.ts`](diffhunk://#diff-d790bc5352c244f25e6384dcfcc0a3e67e768d46705f0ba341310aef7c7f0b39L9-R14): Updated CLI commands to remove the `senderKey` option and utilize the SDK's key. [[1]](diffhunk://#diff-d790bc5352c244f25e6384dcfcc0a3e67e768d46705f0ba341310aef7c7f0b39L9-R14) [[2]](diffhunk://#diff-d790bc5352c244f25e6384dcfcc0a3e67e768d46705f0ba341310aef7c7f0b39L64) [[3]](diffhunk://#diff-d790bc5352c244f25e6384dcfcc0a3e67e768d46705f0ba341310aef7c7f0b39L90) [[4]](diffhunk://#diff-d790bc5352c244f25e6384dcfcc0a3e67e768d46705f0ba341310aef7c7f0b39L131) [[5]](diffhunk://#diff-d790bc5352c244f25e6384dcfcc0a3e67e768d46705f0ba341310aef7c7f0b39L154) [[6]](diffhunk://#diff-d790bc5352c244f25e6384dcfcc0a3e67e768d46705f0ba341310aef7c7f0b39L179)

### Test Updates:

* [`src/stacks-dao/tests/index.test.ts`](diffhunk://#diff-3064bb9b1f10c73e5daa7cdcf3b47c71807f577449daacc9b23ac77f24301346L10-R17): Modified tests to use the new SDK initialization method and removed the `senderKey` parameter from function calls. [[1]](diffhunk://#diff-3064bb9b1f10c73e5daa7cdcf3b47c71807f577449daacc9b23ac77f24301346L10-R17) [[2]](diffhunk://#diff-3064bb9b1f10c73e5daa7cdcf3b47c71807f577449daacc9b23ac77f24301346L49-R41) [[3]](diffhunk://#diff-3064bb9b1f10c73e5daa7cdcf3b47c71807f577449daacc9b23ac77f24301346L69-R59) [[4]](diffhunk://#diff-3064bb9b1f10c73e5daa7cdcf3b47c71807f577449daacc9b23ac77f24301346L96) [[5]](diffhunk://#diff-3064bb9b1f10c73e5daa7cdcf3b47c71807f577449daacc9b23ac77f24301346L108-R96) [[6]](diffhunk://#diff-3064bb9b1f10c73e5daa7cdcf3b47c71807f577449daacc9b23ac77f24301346L121-R108)

### Type Adjustments:

* [`src/stacks-dao/types/index.ts`](diffhunk://#diff-c5bf666661753ac3ec15143a3d305f757a19834144c6c01a26328448b2992ca4L58-R58): Updated `ContractDeployOptions` and `TransactionOptions` to make `senderKey` optional. [[1]](diffhunk://#diff-c5bf666661753ac3ec15143a3d305f757a19834144c6c01a26328448b2992ca4L58-R58) [[2]](diffhunk://#diff-c5bf666661753ac3ec15143a3d305f757a19834144c6c01a26328448b2992ca4L73-R73)