### PR TITLE
Buy Cap Protection + BigInt Support for BTC-denominated Tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@bitflowlabs/core-sdk": "^1.1.0",
-        "@faktoryfun/core-sdk": "^0.2.22",
+        "@faktoryfun/core-sdk": "^0.2.23",
         "@jingcash/core-sdk": "^0.1.10",
         "@stacks/blockchain-api-client": "^8.7.0",
         "@stacks/bns": "^6.17.0",
@@ -474,9 +474,9 @@
       }
     },
     "node_modules/@faktoryfun/core-sdk": {
-      "version": "0.2.22",
-      "resolved": "https://registry.npmjs.org/@faktoryfun/core-sdk/-/core-sdk-0.2.22.tgz",
-      "integrity": "sha512-yGsVN7dN4kIkDcNarldFcI7hchD12KkQ8KPaAqBf2yC9lRlgsnV7vdDflhfdDOqu1aXpdcgHiSOnL+y34TYBkg==",
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@faktoryfun/core-sdk/-/core-sdk-0.2.23.tgz",
+      "integrity": "sha512-d5W+73rY1cSymR5zrrt8DmjXst+/bqKe5wIuEknXpcsg+b33wJNVAxWqWEktWrendNKzbmrPqNaYZy+p3ON7Vw==",
       "license": "MIT",
       "dependencies": {
         "@stacks/network": "^6.17.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@bitflowlabs/core-sdk": "^1.1.0",
-    "@faktoryfun/core-sdk": "^0.2.22",
+    "@faktoryfun/core-sdk": "^0.2.23",
     "@jingcash/core-sdk": "^0.1.10",
     "@stacks/blockchain-api-client": "^8.7.0",
     "@stacks/bns": "^6.17.0",

--- a/src/stacks-faktory/exec-buy.ts
+++ b/src/stacks-faktory/exec-buy.ts
@@ -74,7 +74,7 @@ async function main() {
   const sdk = new FaktorySDK(faktoryConfig);
 
   // Check token denomination
-  console.log("Checking token denomination...");
+  // console.log("Checking token denomination...");
   const tokenInfo = await sdk.getToken(args.dexContract);
   const isBtcDenominated = tokenInfo.data.denomination === "btc";
 
@@ -99,7 +99,7 @@ async function main() {
   // }
 
   // get buy parameters
-  console.log("Getting buy parameters...");
+  // console.log("Getting buy parameters...");
   const buyParams = await sdk.getBuyParams({
     dexContract: args.dexContract,
     inAmount: args.btcAmount, // accepts BTC amount for BTC-denominated tokens


### PR DESCRIPTION
Implements BigInt for 8-decimal BTC tokens to prevent JavaScript number limitations.

Adds amount capping to protect users from over-buying by accident, limiting buys to 15% above the recommended graduation amount while maintaining transaction success.




