### PR TITLE
Standardize stacks-transactions scripts

### DIFF
--- a/src/stacks-transactions/get-transaction-status.ts
+++ b/src/stacks-transactions/get-transaction-status.ts
@@ -1,10 +1,34 @@
-// CONFIGURATION
-
 import { Transaction } from "@stacks/stacks-blockchain-api-types";
-import { CONFIG, getApiUrl } from "../utilities";
+import {
+  CONFIG,
+  createErrorResponse,
+  getApiUrl,
+  sendToLLM,
+  ToolResponse
+} from "../utilities";
+
+const usage = "Usage: bun run get-transaction-status.ts <txId>";
+const usageExample = "Example: bun run get-transaction-status.ts 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+
+interface ExpectedArgs {
+  txId: string;
+}
+
+function validateArgs(): ExpectedArgs {
+  const [txId] = process.argv.slice(2);
+  if (!txId) {
+    const errorMessage = [
+      "No transaction ID provided",
+      usage,
+      usageExample
+    ].join("\n");
+    throw new Error(errorMessage);
+  }
+  return { txId };
+}
 
 // gets transaction data from the API
-async function getTransaction(network: string, txId: string) {
+async function getTransaction(network: string, txId: string): Promise<Transaction> {
   const apiUrl = getApiUrl(network);
   const response = await fetch(`${apiUrl}/extended/v1/tx/${txId}`);
   if (!response.ok) {
@@ -14,24 +38,26 @@ async function getTransaction(network: string, txId: string) {
   return data as Transaction;
 }
 
-async function main() {
-  // expect txId as first argument
-  const txId = process.argv[2];
-  if (!txId) {
-    console.error("No transaction ID provided, exiting...");
-    return;
-  }
-
+async function main(): Promise<ToolResponse<{ txStatus: string }>> {
+  // validate and store provided args
+  const args = validateArgs();
+  
   // get transaction info from API
-  try {
-    const txResponse = await getTransaction(CONFIG.NETWORK, txId);
-    // get transaction status from object
-    const txStatus = txResponse.tx_status;
-    console.log(txStatus);
-  } catch (error) {
-    // report error
-    console.error(`General/Unexpected Failure: ${error}`);
-  }
+  const txResponse = await getTransaction(CONFIG.NETWORK, args.txId);
+  
+  // get transaction status from object
+  const txStatus = txResponse.tx_status;
+  
+  return {
+    success: true,
+    message: `Transaction status retrieved successfully`,
+    data: { txStatus }
+  };
 }
 
-main();
+main()
+  .then(sendToLLM)
+  .catch((error) => {
+    sendToLLM(createErrorResponse(error));
+    process.exit(1);
+  });

--- a/src/stacks-transactions/get-transaction.ts
+++ b/src/stacks-transactions/get-transaction.ts
@@ -1,10 +1,34 @@
-// CONFIGURATION
-
 import { Transaction } from "@stacks/stacks-blockchain-api-types";
-import { CONFIG, getApiUrl } from "../utilities";
+import {
+  CONFIG,
+  createErrorResponse,
+  getApiUrl,
+  sendToLLM,
+  ToolResponse
+} from "../utilities";
+
+const usage = "Usage: bun run get-transaction.ts <txId>";
+const usageExample = "Example: bun run get-transaction.ts 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+
+interface ExpectedArgs {
+  txId: string;
+}
+
+function validateArgs(): ExpectedArgs {
+  const [txId] = process.argv.slice(2);
+  if (!txId) {
+    const errorMessage = [
+      "No transaction ID provided",
+      usage,
+      usageExample
+    ].join("\n");
+    throw new Error(errorMessage);
+  }
+  return { txId };
+}
 
 // gets transaction data from the API
-async function getTransaction(network: string, txId: string) {
+async function getTransaction(network: string, txId: string): Promise<Transaction> {
   const apiUrl = getApiUrl(network);
   const response = await fetch(`${apiUrl}/extended/v1/tx/${txId}`);
   if (!response.ok) {
@@ -14,24 +38,23 @@ async function getTransaction(network: string, txId: string) {
   return data as Transaction;
 }
 
-// MAIN SCRIPT (DO NOT EDIT)
-
-async function main() {
-  // expect txId as first argument
-  const txId = process.argv[2];
-  if (!txId) {
-    console.error("No transaction ID provided, exiting...");
-    return;
-  }
-
+async function main(): Promise<ToolResponse<Transaction>> {
+  // validate and store provided args
+  const args = validateArgs();
+  
   // get transaction info from API
-  try {
-    const txResponse = await getTransaction(CONFIG.NETWORK, txId);
-    console.log(txResponse);
-  } catch (error) {
-    // report error
-    console.error(`General/Unexpected Failure: ${error}`);
-  }
+  const txResponse = await getTransaction(CONFIG.NETWORK, args.txId);
+  
+  return {
+    success: true,
+    message: `Transaction retrieved successfully`,
+    data: txResponse
+  };
 }
 
-main();
+main()
+  .then(sendToLLM)
+  .catch((error) => {
+    sendToLLM(createErrorResponse(error));
+    process.exit(1);
+  });


### PR DESCRIPTION
Use new patterns for error handling / output as established in `aibtc-dao`

Resolves a bug where the `events` key in the transaction details object was showing `[Object, object]` instead of reporting the full value, blocking the retrieval of successful transaction events from the json.