### PR TITLE
Standardize aibtc core request body

### DIFF
--- a/src/aibtc-cohort-0/contract-tools/deploy-dao-contracts.ts
+++ b/src/aibtc-cohort-0/contract-tools/deploy-dao-contracts.ts
@@ -28,7 +28,7 @@ import { saveDaoContractsToFiles } from "../utils/save-contract";
 import { ContractResponse, CONTRACT_NAMES } from "@aibtc/types";
 
 const usage =
-  "Usage: bun run deploy-dao-contracts.ts <tokenSymbol> <tokenUri> <originAddress> <daoManifest> [tweetOrigin] [network] [saveToFile]";
+  "Usage: bun run deploy-dao-contracts.ts <tokenSymbol> <tokenUri> <originAddress> <daoManifest> <tweetOrigin> [network] [saveToFile]";
 const usageExample =
   'Example: bun run deploy-dao-contracts.ts MYTOKEN "https://example.com/token.json" ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM "This is my DAO" "1894855072556912681" "testnet" true';
 
@@ -38,7 +38,7 @@ interface ExpectedArgs {
   tokenUri: string;
   originAddress: string;
   daoManifest: string;
-  tweetOrigin?: string;
+  tweetOrigin: string;
   network?: string;
   saveToFile?: boolean;
   // buld replacements from params
@@ -51,7 +51,7 @@ function validateArgs(): ExpectedArgs {
     tokenUri,
     originAddress,
     daoManifest,
-    tweetOrigin = "",
+    tweetOrigin,
     network = CONFIG.NETWORK,
     saveToFileStr = "false",
   ] = process.argv.slice(2);
@@ -118,7 +118,7 @@ function validateArgs(): ExpectedArgs {
     saveToFile,
     customReplacements: {
       dao_manifest: daoManifest,
-      tweet_origin: tweetOrigin || "",
+      tweet_origin: tweetOrigin,
       origin_address: originAddress,
       dao_token_metadata: tokenUri,
       dao_token_symbol: tokenSymbolLower,
@@ -177,7 +177,7 @@ async function main(): Promise<ToolResponse<BroadcastedAndPostedResponse>> {
       uri: args.tokenUri,
       logoUrl: imageUrl, // Use imageUrl fetched earlier
       description: args.daoManifest,
-      tweetOrigin: args.tweetOrigin || "",
+      tweetOrigin: args.tweetOrigin,
     };
     const {
       prelaunch: faktoryPrelaunch,
@@ -224,19 +224,24 @@ async function main(): Promise<ToolResponse<BroadcastedAndPostedResponse>> {
 
     //console.log("Generated contracts:", contractsToProcess); // Updated variable
     // sort them by deployment order
-    const contracts = contractsToProcess.sort( // Use the updated contractsToProcess list
+    const contracts = contractsToProcess.sort(
+      // Use the updated contractsToProcess list
       (a, b) => a.deploymentOrder - b.deploymentOrder
     );
 
     // Save contracts to files if requested
     if (args.saveToFile) {
-      await saveDaoContractsToFiles(contracts, args.tokenSymbolLower, network);
+      await saveDaoContractsToFiles(
+        contracts,
+        args.tokenSymbolLower,
+        currentNetwork
+      );
     }
 
     const deploymentOptions: DeploymentOptions = {
       address,
       key,
-      network,
+      network: currentNetwork,
       nonce: currentNonce,
     };
 

--- a/src/aibtc-cohort-0/contract-tools/deploy-dao-contracts.ts
+++ b/src/aibtc-cohort-0/contract-tools/deploy-dao-contracts.ts
@@ -125,7 +125,9 @@ function validateArgs(): ExpectedArgs {
 }
 
 async function main(): Promise<ToolResponse<BroadcastedAndPostedResponse>> {
+  // validate and store provided args
   const args = validateArgs();
+  // create new api client for aibtcdev-daos API
   const apiClient = new ContractApiClient();
 
   try {

--- a/src/aibtc-cohort-0/contract-tools/generate-dao-contracts.ts
+++ b/src/aibtc-cohort-0/contract-tools/generate-dao-contracts.ts
@@ -3,18 +3,26 @@ import {
   CONFIG,
   convertStringToBoolean,
   createErrorResponse,
+  deriveChildAccount,
+  FaktoryRequestBody,
+  getFaktoryContracts,
+  getImageUrlFromTokenUri,
   sendToLLM,
   ToolResponse,
 } from "../../utilities";
 import { validateStacksAddress } from "@stacks/transactions";
-import { GeneratedDaoContractsResponse, ContractResponse } from "@aibtc/types";
+import {
+  GeneratedDaoContractsResponse,
+  ContractResponse,
+  CONTRACT_NAMES,
+} from "@aibtc/types";
 import {
   getContractDisplayName,
   saveDaoContractsToFiles,
 } from "../utils/save-contract";
 
 const usage =
-  "Usage: bun run generate-dao-contracts.ts <tokenSymbol> <tokenUri> <originAddress> <daoManifest> [tweetOrigin] [network] [saveToFile]";
+  "Usage: bun run generate-dao-contracts.ts <tokenSymbol> <tokenUri> <originAddress> <daoManifest> <tweetOrigin> [network] [saveToFile]";
 const usageExample =
   'Example: bun run generate-dao-contracts.ts MYTOKEN "https://example.com/token.json" ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM "This is my DAO" "1894855072556912681" "testnet" true';
 
@@ -23,7 +31,7 @@ interface ExpectedArgs {
   tokenUri: string;
   originAddress: string;
   daoManifest: string;
-  tweetOrigin?: string;
+  tweetOrigin: string;
   network?: string;
   saveToFile?: boolean;
   // buld replacements from params
@@ -36,7 +44,7 @@ function validateArgs(): ExpectedArgs {
     tokenUri,
     originAddress,
     daoManifest,
-    tweetOrigin = "",
+    tweetOrigin,
     network = CONFIG.NETWORK,
     saveToFileStr = "false",
   ] = process.argv.slice(2);
@@ -81,13 +89,13 @@ function validateArgs(): ExpectedArgs {
     tokenUri,
     originAddress,
     daoManifest,
-    tweetOrigin: tweetOrigin || undefined,
+    tweetOrigin,
     network: network || CONFIG.NETWORK,
     saveToFile,
     // buld replacements from params
     customReplacements: {
       dao_manifest: daoManifest,
-      tweet_origin: tweetOrigin || "",
+      tweet_origin: tweetOrigin,
       origin_address: originAddress,
       dao_token_metadata: tokenUri,
       dao_token_symbol: tokenSymbol,
@@ -96,10 +104,19 @@ function validateArgs(): ExpectedArgs {
 }
 
 async function main(): Promise<ToolResponse<GeneratedDaoContractsResponse>> {
+  // validate and store provided args
   const args = validateArgs();
+  // setup network and wallet info
+  const { address } = await deriveChildAccount(
+    CONFIG.NETWORK,
+    CONFIG.MNEMONIC,
+    CONFIG.ACCOUNT_INDEX
+  );
+  // create new api client for aibtcdev-daos API
   const apiClient = new ContractApiClient();
 
   try {
+    // generate DAO contracts
     const result = await apiClient.generateDaoContracts(
       args.network,
       args.tokenSymbol,
@@ -115,10 +132,56 @@ async function main(): Promise<ToolResponse<GeneratedDaoContractsResponse>> {
       );
     }
 
-    const network = args.network || CONFIG.NETWORK;
-
     //console.log("Result data:", Object.keys(result.data));
     const contracts = result.data.contracts;
+
+    const network = args.network || CONFIG.NETWORK;
+    // fetch token URI, get image link
+    const imageUrl = await getImageUrlFromTokenUri(args.tokenUri);
+
+    // get latest faktory contracts from endpoint
+    const requestBody: FaktoryRequestBody = {
+      symbol: args.tokenSymbol,
+      name: args.tokenSymbol,
+      supply: 1000000000, // 1 billion tokens
+      creatorAddress: address,
+      originAddress: args.originAddress,
+      uri: args.tokenUri,
+      logoUrl: imageUrl,
+      description: args.daoManifest,
+      tweetOrigin: args.tweetOrigin,
+    };
+    const { prelaunch, token, dex, pool } = await getFaktoryContracts(
+      requestBody
+    ); // name, code, hash, contract
+
+    // find matching contracts from our generated contracts
+    const prelaunchMatch = contracts.find(
+      (c) => c.name === CONTRACT_NAMES.TOKEN.PRELAUNCH
+    );
+    const tokenMatch = contracts.find(
+      (c) => c.name === CONTRACT_NAMES.TOKEN.DAO
+    );
+    const dexMatch = contracts.find((c) => c.name === CONTRACT_NAMES.TOKEN.DEX);
+    const poolMatch = contracts.find(
+      (c) => c.name === CONTRACT_NAMES.TOKEN.POOL
+    );
+
+    // verify all matches were found
+    if (!prelaunchMatch || !tokenMatch || !dexMatch || !poolMatch) {
+      throw new Error(
+        `Failed to find all required contracts in generated contracts: prelaunch, token, dex, pool`
+      );
+    }
+    // update contract sources and hashes
+    prelaunchMatch.source = prelaunch.code;
+    prelaunchMatch.hash = prelaunch.hash;
+    tokenMatch.source = token.code;
+    tokenMatch.hash = token.hash;
+    dexMatch.source = dex.code;
+    dexMatch.hash = dex.hash;
+    poolMatch.source = pool.code;
+    poolMatch.hash = pool.hash;
 
     // Save contracts to files if requested
     if (args.saveToFile) {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1172,27 +1172,6 @@ export function getAibtcCoreApiUrl(network: string) {
 export type aibtcCoreRequestBody = {
   name: string;
   mission: string;
-  description: string;
-  extensions: DeployedContractRegistryEntry[] | ContractResponse[];
-  token: {
-    name: string;
-    symbol: string;
-    decimals: number;
-    description: string;
-    max_supply: string;
-    uri: string;
-    tx_id: string;
-    contract_principal: string;
-    image_url: string;
-    x_url?: string;
-    telegram_url?: string;
-    website_url?: string;
-  };
-};
-
-export type aibtcCoreRequestBodyV2 = {
-  name: string;
-  mission: string;
   contracts: aibtcCoreRequestContract[];
   token_info: aibtcCoreRequestTokenInfo;
 };

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -30,7 +30,7 @@ import {
 } from "./aibtc-dao/registries/dao-contract-registry";
 import { ContractCallsClient } from "./api/contract-calls-client";
 import { TokenInfoService } from "./api/token-info-service";
-import { ContractResponse } from "@aibtc/types";
+import { ContractResponse, ContractSubtype, ContractType } from "@aibtc/types";
 
 //////////////////////////////
 // GENERAL HELPERS
@@ -1188,6 +1188,35 @@ export type aibtcCoreRequestBody = {
     telegram_url?: string;
     website_url?: string;
   };
+};
+
+export type aibtcCoreRequestBodyV2 = {
+  name: string;
+  mission: string;
+  description: string;
+  contracts: aibtcCoreRequestContract[];
+  token_info: aibtcCoreRequestTokenInfo;
+};
+
+type aibtcCoreRequestContract = {
+  name: string; // matches repo contract names
+  display_name: string; // has token symbol in it
+  type: ContractType; // type e.g. "EXTENSIONS", "ACTIONS"
+  subtype: ContractSubtype<ContractType>; // subtype e.g. "ONCHAIN_MESSAGING", "SEND_MESSAGE"
+  tx_id: string;
+  deployer: string;
+  contract_principal: string;
+};
+
+type aibtcCoreRequestTokenInfo = {
+  symbol: string; // removed name and desc, same value
+  decimals: number; // can hardcode as 8?
+  max_supply: string; // can hardcode 1B + decimals?
+  uri: string; // JSON URL for the token metadata
+  image_url: string; // image URL for the token
+  x_url?: string;
+  telegram_url?: string;
+  website_url?: string;
 };
 
 export async function postToAibtcCore(

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1193,7 +1193,6 @@ export type aibtcCoreRequestBody = {
 export type aibtcCoreRequestBodyV2 = {
   name: string;
   mission: string;
-  description: string;
   contracts: aibtcCoreRequestContract[];
   token_info: aibtcCoreRequestTokenInfo;
 };

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1197,7 +1197,7 @@ export type aibtcCoreRequestBodyV2 = {
   token_info: aibtcCoreRequestTokenInfo;
 };
 
-type aibtcCoreRequestContract = {
+export type aibtcCoreRequestContract = {
   name: string; // matches repo contract names
   display_name: string; // has token symbol in it
   type: ContractType; // type e.g. "EXTENSIONS", "ACTIONS"
@@ -1207,7 +1207,7 @@ type aibtcCoreRequestContract = {
   contract_principal: string;
 };
 
-type aibtcCoreRequestTokenInfo = {
+export type aibtcCoreRequestTokenInfo = {
   symbol: string; // removed name and desc, same value
   decimals: number; // can hardcode as 8?
   max_supply: string; // can hardcode 1B + decimals?


### PR DESCRIPTION
Now that we have the dedicated registry in [aibtcdev/aibtcdev-daos](https://github.com/aibtcdev/aibtcdev-daos) we can start using the types and subtypes for contracts as a single source of truth when passing data throughout the different parts of our application.

Type, subtype, and contract names are:
- defined in the [aibtcdev-daos repo](https://github.com/aibtcdev/aibtcdev-daos/blob/main/utilities/contract-types.ts)
- exposed in the [aibtcdev-daos API](https://daos.aibtc.dev/api/types)
- exposed in the [@aibtc/types npm package](https://www.npmjs.com/package/@aibtc/types)

Specifically for the request to AIBTC core, this PR would define the object we need to build and pass to the backend when a new DAO is deployed.