### PR TITLE
Refactor: use approval from types

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
         "tslib": "^2.8.1",
       },
       "devDependencies": {
-        "@aibtc/types": "^0.10.0",
+        "@aibtc/types": "^0.11.0",
         "@types/bun": "^1.2.19",
         "@types/node": "^24.0.15",
         "bun-types": "^1.2.19",
@@ -37,7 +37,7 @@
     },
   },
   "packages": {
-    "@aibtc/types": ["@aibtc/types@0.10.0", "", {}, "sha512-LNQ44zbAnCRqDYMXzhFFZb7q3FFNf5TwVeTMRpbw1c7E2zXVIObFERgLP2niUTUQvfka5Vszb3jbAyfIy3l8+g=="],
+    "@aibtc/types": ["@aibtc/types@0.11.0", "", {}, "sha512-BnGiHaPkLd4RJwPG0PBEO5Lj4wuJmGwOdLklN6aNkggb/0FmL+fHH9zMD+ZO1OefgdrPON/drL3bJN2JjOeFUA=="],
 
     "@bitflowlabs/core-sdk": ["@bitflowlabs/core-sdk@2.4.0", "", { "dependencies": { "@stacks/connect": "^7.10.2", "@stacks/network": "^7.0.2", "@stacks/transactions": "^7.0.5", "dotenv": "^16.4.7" } }, "sha512-ii9W0/dfRb0tkw0Y44KJ+40VkHnH2a+Wgj+aWvcyCkFU9iE2LlQ3AQMZA+W1MHxTgBzah34ouzEs1+F6xhkSdg=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "tslib": "^2.8.1"
       },
       "devDependencies": {
-        "@aibtc/types": "^0.10.0",
+        "@aibtc/types": "^0.11.0",
         "@types/bun": "^1.2.19",
         "@types/node": "^24.0.15",
         "bun-types": "^1.2.19",
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@aibtc/types": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aibtc/types/-/types-0.10.0.tgz",
-      "integrity": "sha512-LNQ44zbAnCRqDYMXzhFFZb7q3FFNf5TwVeTMRpbw1c7E2zXVIObFERgLP2niUTUQvfka5Vszb3jbAyfIy3l8+g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aibtc/types/-/types-0.11.0.tgz",
+      "integrity": "sha512-BnGiHaPkLd4RJwPG0PBEO5Lj4wuJmGwOdLklN6aNkggb/0FmL+fHH9zMD+ZO1OefgdrPON/drL3bJN2JjOeFUA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@aibtc/types": "^0.10.0",
+    "@aibtc/types": "^0.11.0",
     "@types/bun": "^1.2.19",
     "@types/node": "^24.0.15",
     "bun-types": "^1.2.19",

--- a/src/aibtc-cohort-0/agent-account/public/approve-contract.ts
+++ b/src/aibtc-cohort-0/agent-account/public/approve-contract.ts
@@ -4,10 +4,7 @@ import {
   SignedContractCallOptions,
   PostConditionMode,
 } from "@stacks/transactions";
-import {
-  AGENT_ACCOUNT_APPROVAL_TYPES,
-  AgentAccountApprovalType,
-} from "../../../aibtc-dao/types/dao-types";
+import { getAgentAccountApprovalType } from "@aibtc/types";
 import {
   broadcastTx,
   CONFIG,
@@ -60,32 +57,11 @@ function validateArgs(): ExpectedArgs {
     throw new Error(errorMessage);
   }
 
-  let numericType: number | undefined;
-  const approvalTypeNumber = parseInt(approvalTypeInput, 10);
-  const validValues = Object.values(AGENT_ACCOUNT_APPROVAL_TYPES);
-
-  if (!isNaN(approvalTypeNumber)) {
-    if (validValues.includes(approvalTypeNumber as any)) {
-      numericType = approvalTypeNumber;
-    }
-  } else {
-    const upperApprovalType =
-      approvalTypeInput.toUpperCase() as AgentAccountApprovalType;
-    if (upperApprovalType in AGENT_ACCOUNT_APPROVAL_TYPES) {
-      numericType = AGENT_ACCOUNT_APPROVAL_TYPES[upperApprovalType];
-    }
-  }
-
-  if (numericType === undefined) {
-    const validOptions = [
-      ...Object.keys(AGENT_ACCOUNT_APPROVAL_TYPES),
-      ...validValues,
-    ].join(", ");
-    const errorMessage = [
-      `Invalid approval type: ${approvalTypeInput}. Must be one of ${validOptions}`,
-      usage,
-      usageExample,
-    ].join("\n");
+  let numericType: number;
+  try {
+    numericType = getAgentAccountApprovalType(approvalTypeInput);
+  } catch (error: any) {
+    const errorMessage = [error.message, usage, usageExample].join("\n");
     throw new Error(errorMessage);
   }
 

--- a/src/aibtc-cohort-0/agent-account/public/revoke-contract.ts
+++ b/src/aibtc-cohort-0/agent-account/public/revoke-contract.ts
@@ -4,10 +4,7 @@ import {
   SignedContractCallOptions,
   PostConditionMode,
 } from "@stacks/transactions";
-import {
-  AGENT_ACCOUNT_APPROVAL_TYPES,
-  AgentAccountApprovalType,
-} from "../../../aibtc-dao/types/dao-types";
+import { getAgentAccountApprovalType } from "@aibtc/types";
 import {
   broadcastTx,
   CONFIG,
@@ -60,32 +57,11 @@ function validateArgs(): ExpectedArgs {
     throw new Error(errorMessage);
   }
 
-  let numericType: number | undefined;
-  const revocationTypeNumber = parseInt(revocationTypeInput, 10);
-  const validValues = Object.values(AGENT_ACCOUNT_APPROVAL_TYPES);
-
-  if (!isNaN(revocationTypeNumber)) {
-    if (validValues.includes(revocationTypeNumber as any)) {
-      numericType = revocationTypeNumber;
-    }
-  } else {
-    const upperRevocationType =
-      revocationTypeInput.toUpperCase() as AgentAccountApprovalType;
-    if (upperRevocationType in AGENT_ACCOUNT_APPROVAL_TYPES) {
-      numericType = AGENT_ACCOUNT_APPROVAL_TYPES[upperRevocationType];
-    }
-  }
-
-  if (numericType === undefined) {
-    const validOptions = [
-      ...Object.keys(AGENT_ACCOUNT_APPROVAL_TYPES),
-      ...validValues,
-    ].join(", ");
-    const errorMessage = [
-      `Invalid revocation type: ${revocationTypeInput}. Must be one of ${validOptions}`,
-      usage,
-      usageExample,
-    ].join("\n");
+  let numericType: number;
+  try {
+    numericType = getAgentAccountApprovalType(revocationTypeInput);
+  } catch (error: any) {
+    const errorMessage = [error.message, usage, usageExample].join("\n");
     throw new Error(errorMessage);
   }
 

--- a/src/aibtc-dao/types/dao-types.ts
+++ b/src/aibtc-dao/types/dao-types.ts
@@ -394,15 +394,3 @@ export interface ResourceData {
   url?: string;
 }
 
-//////////////////////////////
-// AGENT ACCOUNT TYPES
-//////////////////////////////
-
-export const AGENT_ACCOUNT_APPROVAL_TYPES = {
-  VOTING: 1,
-  SWAP: 2,
-  TOKEN: 3,
-} as const;
-
-export type AgentAccountApprovalType =
-  keyof typeof AGENT_ACCOUNT_APPROVAL_TYPES;


### PR DESCRIPTION
Instead of hardcoding we can get this from types package now thanks to https://github.com/aibtcdev/aibtcdev-daos/commit/998fc7bc1e0695780a4ee46e20fd0cf0ba5febd7